### PR TITLE
Fix multi-gpu bug

### DIFF
--- a/experiments/training/trainer.py
+++ b/experiments/training/trainer.py
@@ -395,7 +395,7 @@ class Trainer(BaseTrainer):
         
         for i_batch, batch_data in enumerate(train_loader):
             if i_batch == 0 and i_epoch == 0:
-                self.first_batch(batch_data)
+                self.first_batch(batch_data, forward_kwargs)
             batch_loss, batch_loss_contributions = self.batch_train(
                 batch_data, loss_functions, loss_weights, optimizer, clip_gradient, parameters,sig2,noise_type,i_epoch, forward_kwargs=forward_kwargs, custom_kwargs=custom_kwargs
             )
@@ -474,7 +474,7 @@ class Trainer(BaseTrainer):
 
         for batch_data in train_loader:
             if i_batch == 0 and i_epoch == 0:
-                self.first_batch(batch_data)
+                self.first_batch(batch_data, forward_kwargs)
             batch_loss, batch_loss_contributions = self.batch_train(
                 batch_data, loss_functions, loss_weights, optimizer, clip_gradient, parameters,sig2,noise_type,i_epoch,forward_kwargs=forward_kwargs, custom_kwargs=custom_kwargs
             )
@@ -574,13 +574,13 @@ class Trainer(BaseTrainer):
 class ForwardTrainer(Trainer):
     """ Trainer for likelihood-based flow training when the model is not conditional. """
 
-    def first_batch(self, batch_data):
+    def first_batch(self, batch_data, forward_kwargs):
         if self.multi_gpu:
             x, y = batch_data
             if len(x.size()) < 2:
                 x = x.view(x.size(0), -1)
             x = x.to(self.device, self.dtype)
-            self.model(x[: x.shape[0] // torch.cuda.device_count(), ...])
+            self.model(x[: x.shape[0] // torch.cuda.device_count(), ...], **forward_kwargs)
 
     def add_noise(self,dataset,noise_type,x,sig2):
         if noise_type == 'gaussian':            


### PR DESCRIPTION
Whenever there is more than one GPU, the code invokes `first_batch` that goes on to call `self.model()`. While other instantiations of `self.model()` pass on `forward_kwargs`, the implementation of `first_batch` does not which leads to some problems. I have patched it by simply passing on `forward_kwargs` wherever necessary. Tested on different number of GPUs.